### PR TITLE
Enable text selection on header cells

### DIFF
--- a/media/parquetExplorer.css
+++ b/media/parquetExplorer.css
@@ -62,6 +62,10 @@ code-input pre {
     flex-grow: 1;
 }
 
+.tabulator-header .tabulator-col {
+    user-select: text;
+}
+
 .tabulator-col {
     background-color: color-mix(in srgb, var(--vscode-editor-foreground), transparent 90%) !important;
     color: var(--vscode-editor-foreground) !important;


### PR DESCRIPTION
This PR enables text selection on Tabulator headers by adding extra CSS. Since the table currently does not support sorting or reordering, this change does not interfere with any existing header functionality.

Resolves #16